### PR TITLE
Fix Kaggle auth and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ML-UQ-Review
-Review and Performance Evaluation of Uncertainty Quantification in Machine Leaning-Assisted Measurements
+Review and Performance Evaluation of Uncertainty Quantification in Machine Learning-Assisted Measurements
 
 # Kaggle API
 https://www.kaggle.com/docs/api

--- a/datasets/data_downloader.py
+++ b/datasets/data_downloader.py
@@ -1,5 +1,8 @@
 import kaggle
 
+# Authenticate using Kaggle API before downloading datasets
+kaggle.api.authenticate()
+
 # Download dataset (replace with the dataset name)
 cs = "parisrohan/credit-score-classification"
 kaggle.api.dataset_download_files(cs, path="./datasets/credit_score", unzip=True)


### PR DESCRIPTION
## Summary
- authenticate Kaggle API before downloads
- fix a spelling error in README

## Testing
- `python -m py_compile datasets/data_downloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68505d0160d0832198d2841c3816e9cb