### PR TITLE
Refactor dataset downloader

### DIFF
--- a/datasets/data_downloader.py
+++ b/datasets/data_downloader.py
@@ -1,25 +1,32 @@
+"""Utility for downloading Kaggle datasets used in this project."""
+
+import os
 import kaggle
 
-# Authenticate using Kaggle API before downloading datasets
-kaggle.api.authenticate()
+DATASETS = {
+    "credit_score": "parisrohan/credit-score-classification",
+    # Correct dataset identifier includes a dash between "depressive" and "non"
+    "tweets": "mexwell/depressive-non-depressive-tweets-data",
+    "ai_vs_human": "shanegerami/ai-vs-human-text",
+    "neo": "ivansher/nasa-nearest-earth-objects-1910-2024",
+}
 
-# Download dataset (replace with the dataset name)
-cs = "parisrohan/credit-score-classification"
-kaggle.api.dataset_download_files(cs, path="./datasets/credit_score", unzip=True)
 
-print(f"Downloaded dataset: Credit Score")
+def download_all() -> None:
+    """Download each dataset and report any failures."""
 
-tweets = "mexwell/depressivenon-depressive-tweets-data"
-kaggle.api.dataset_download_files(tweets, path="./datasets/tweets", unzip=True)
+    kaggle.api.authenticate()
 
-print(f"Downloaded dataset: Tweets")
+    for folder, dataset_id in DATASETS.items():
+        dest = os.path.join("./datasets", folder)
+        try:
+            kaggle.api.dataset_download_files(dataset_id, path=dest, unzip=True)
+            if not any(os.scandir(dest)):
+                raise RuntimeError("download produced an empty directory")
+            print(f"Downloaded dataset: {folder} ({dataset_id})")
+        except Exception as err:  # noqa: BLE001
+            print(f"Failed to download {dataset_id}: {err}")
 
-ah = "shanegerami/ai-vs-human-text"
-kaggle.api.dataset_download_files(ah, path="./datasets/ai_vs_human", unzip=True)
 
-print("Downloaded dataset: AI vs. Human")
-
-neo = "ivansher/nasa-nearest-earth-objects-1910-2024"
-kaggle.api.dataset_download_files(neo, path="./datasets/neo", unzip=True)
-
-print("Downloaded dataset: NEO")
+if __name__ == "__main__":
+    download_all()


### PR DESCRIPTION
## Summary
- refactor Kaggle downloader to use a dictionary and loop
- correct tweets dataset identifier and validate downloads
- trim README dataset section

## Testing
- `python -m py_compile datasets/data_downloader.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686601996f8c8321beabb6afb0801b1e