### PR TITLE
Add JSON output for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Two ways to run it:
   ```
 
 Output plots (PNG and EPS) are written to the corresponding dataset folder.
+In the same directory, a `*_results.json` file captures the exact metric values
+used to generate the figures. It contains the uncertainty bins, per-bin metrics
+and overall performance comparisons against the MP baseline.
 
 ## Directory overview
 - `datasets/` – dataset downloader and downloaded data. After running the downloader, subfolders such as `mnist` or `credit_score` will appear here. Evaluation results from `main.py` are also saved in these folders.

--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ from utils import (
     std_predicted_prob,
     compute_truth_flags,
     build_bins_from_arrays,
+    compute_overall_metrics,
+    save_results_json,
     plot_all
 )
 
@@ -45,6 +47,9 @@ def main():
         slices=10
     )
 
+    # Compute overall metrics and store exact arrays
+    metrics = compute_overall_metrics(y, preds0, preds_mc)
+
     # 5.  Plot everything
     output_dir = os.path.join(
         'datasets',
@@ -53,6 +58,8 @@ def main():
     prefix = os.path.splitext(os.path.basename(args.model_path))[0]
 
     plot_all(u_lists, m_lists, c_lists, output_dir, prefix)
+    json_path = os.path.join(output_dir, f"{prefix}_results.json")
+    save_results_json(u_lists, m_lists, c_lists, metrics, json_path)
     print("Done.")
 
 if __name__ == "__main__":

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,5 +2,5 @@ from .arguments import parse_args
 from .build_model import load_data
 from .inference import run_mc_dropout, compute_truth_flags
 from .uncertainty_quantification import misclassification_probability, entropy, std_predicted_prob
-from .metrics import build_bins_from_arrays
+from .metrics import build_bins_from_arrays, compute_overall_metrics, save_results_json
 from .plotting import plot_all

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -2,7 +2,13 @@
 #  Binning helpers (vectorised, safe for empty bins)
 # ---------------------------------------------------------------------
 import numpy as np
-from sklearn.metrics import precision_score, recall_score, f1_score
+from sklearn.metrics import (
+    precision_score,
+    recall_score,
+    f1_score,
+    accuracy_score,
+)
+import json
 
 def cal_bin(uc, truth_flags, slices=10, return_rate=True):
     """Per-bin accuracy *or* count, NaN for empty bins."""
@@ -93,4 +99,64 @@ def build_bins_from_arrays(
         m_lists[name] = cal_bin_others(y_true_bins, y_pred_bins)
 
     return u_lists, m_lists, c_lists
+
+
+# ---------------------------------------------------------------------
+#  Additional helpers: overall metrics and JSON output
+# ---------------------------------------------------------------------
+
+def _overall_metrics(y_true, preds):
+    """Return 10 common metrics for a set of predictions."""
+    return np.array([
+        accuracy_score(y_true, preds),
+        precision_score(y_true, preds, average='macro'),
+        precision_score(y_true, preds, average='micro'),
+        precision_score(y_true, preds, average='weighted'),
+        recall_score(y_true, preds, average='macro'),
+        recall_score(y_true, preds, average='micro'),
+        recall_score(y_true, preds, average='weighted'),
+        f1_score(y_true, preds, average='macro'),
+        f1_score(y_true, preds, average='micro'),
+        f1_score(y_true, preds, average='weighted'),
+    ], dtype=float)
+
+
+def compute_overall_metrics(y_onehot, preds0, preds_mc):
+    """Compute metrics for all five methods."""
+    labels = y_onehot.argmax(axis=1)
+    metrics = {
+        'MP': _overall_metrics(labels, preds0),
+        'MP_MC': _overall_metrics(labels, preds_mc),
+        'Entropy': _overall_metrics(labels, preds0),
+        'Entropy_MC': _overall_metrics(labels, preds_mc),
+        'DPP': _overall_metrics(labels, preds_mc),
+    }
+    return metrics
+
+
+def save_results_json(u_lists, m_lists, c_lists, metrics, out_path):
+    """Save arrays and metric comparisons to a JSON file."""
+
+    def conv(d):
+        return {k: np.asarray(v).tolist() for k, v in d.items()}
+
+    data = {
+        'u_lists': conv(u_lists),
+        'm_lists': conv(m_lists),
+        'c_lists': conv(c_lists),
+        'overall_metrics': {k: np.asarray(v).tolist() for k, v in metrics.items()},
+    }
+
+    mp = metrics.get('MP')
+    if mp is not None:
+        comp = {}
+        for method, vals in metrics.items():
+            if method == 'MP':
+                continue
+            comp[method] = (np.asarray(vals) - mp).tolist()
+        data['comparison_to_MP'] = comp
+
+    with open(out_path, 'w') as f:
+        json.dump(data, f, indent=2)
+
 


### PR DESCRIPTION
## Summary
- extend README with JSON results file info
- expose new utilities for computing metrics and saving JSON
- implement overall metrics comparison in `utils.metrics`
- use metrics helpers in `main.py` and save a results JSON file

## Testing
- `python main.py --dataset mnist` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68663aed12ec832195531c22e5577083