### PR TITLE
Add metric diff summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Two ways to run it:
   ```
 
 Output plots (PNG and EPS) are written to the corresponding dataset folder.
+In the same directory, a `*_results.json` file captures the arrays used to
+generate the figures. It stores the uncertainty bins (`u_lists`, `m_lists`,
+`c_lists`) and summaries of how each method differs from MP across ten
+classification metrics.
 
 ## Directory overview
 - `datasets/` – dataset downloader and downloaded data. After running the downloader, subfolders such as `mnist` or `credit_score` will appear here. Evaluation results from `main.py` are also saved in these folders.

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import numpy as np
 import os 
 
-from utils import ( 
+from utils import (
     parse_args,
     load_data,
     run_mc_dropout,
@@ -10,7 +10,9 @@ from utils import (
     std_predicted_prob,
     compute_truth_flags,
     build_bins_from_arrays,
-    plot_all
+    summarise_metric_diffs,
+    save_results_json,
+    plot_all,
 )
 
 
@@ -45,6 +47,9 @@ def main():
         slices=10
     )
 
+    # Summarise per-bin metric differences
+    diff_summary = summarise_metric_diffs(u_lists, m_lists)
+
     # 5.  Plot everything
     output_dir = os.path.join(
         'datasets',
@@ -53,6 +58,8 @@ def main():
     prefix = os.path.splitext(os.path.basename(args.model_path))[0]
 
     plot_all(u_lists, m_lists, c_lists, output_dir, prefix)
+    json_path = os.path.join(output_dir, f"{prefix}_results.json")
+    save_results_json(u_lists, m_lists, c_lists, diff_summary, json_path)
     print("Done.")
 
 if __name__ == "__main__":

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,5 +2,9 @@ from .arguments import parse_args
 from .build_model import load_data
 from .inference import run_mc_dropout, compute_truth_flags
 from .uncertainty_quantification import misclassification_probability, entropy, std_predicted_prob
-from .metrics import build_bins_from_arrays
+from .metrics import (
+    build_bins_from_arrays,
+    summarise_metric_diffs,
+    save_results_json,
+)
 from .plotting import plot_all


### PR DESCRIPTION
## Summary
- export `summarise_metric_diffs` from utils
- compute per-bin metric difference summaries and save in JSON
- document JSON output in README
- drop unused overall metric code

## Testing
- `python -m py_compile main.py utils/metrics.py utils/__init__.py`
- `python main.py --dataset mnist` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68663aed12ec832195531c22e5577083