### PR TITLE
Document training and evaluation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ The project uses Kaggle to obtain benchmark datasets. To download them:
    ```
    Each dataset will be extracted under `datasets/<name>`.
 
+## Training models
+After the datasets are downloaded, train the corresponding models:
+
+```bash
+bash train.sh
+```
+
+This script iterates over every dataset and stores the trained model in its
+respective folder. Once training is complete, you can evaluate a dataset with
+`main.py` as described below.
+
 ## Running `main.py`
 `main.py` evaluates a trained model using MC Dropout and generates plots summarising uncertainty metrics.
 
@@ -43,6 +54,15 @@ In the same directory, a `*_results.json` file captures the arrays used to
 generate the figures. It stores the uncertainty bins (`u_lists`, `m_lists`,
 `c_lists`) and summaries of how each method differs from MP across ten
 classification metrics.
+
+## Evaluating all datasets
+To run `main.py` for every dataset in a single command, use the helper script:
+
+```bash
+bash evaluate.sh
+```
+
+This will sequentially evaluate each dataset using its trained model.
 
 
 ## Directory overview


### PR DESCRIPTION
## Summary
- add training workflow instructions and evaluate.sh usage to README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac9dfafe708321ad946019189fb6d6