### PR TITLE
Fix requirements to be pip-installable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,11 @@
 absl-py==2.1.0
-asttokens @ file:///home/conda/feedstock_root/build_artifacts/asttokens_1733250440834/work
 astunparse==1.6.3
 bleach==6.2.0
 certifi==2025.1.31
 charset-normalizer==3.4.1
 click==8.1.8
-comm @ file:///home/conda/feedstock_root/build_artifacts/comm_1733502965406/work
 contourpy==1.3.1
 cycler==0.12.1
-debugpy @ file:///croot/debugpy_1736267418885/work
-decorator @ file:///home/conda/feedstock_root/build_artifacts/decorator_1740384970518/work
-exceptiongroup @ file:///home/conda/feedstock_root/build_artifacts/exceptiongroup_1733208806608/work
-executing @ file:///home/conda/feedstock_root/build_artifacts/executing_1733569351617/work
 flatbuffers==25.2.10
 fonttools==4.56.0
 gast==0.6.0
@@ -20,15 +14,7 @@ grpcio==1.70.0
 h5py==3.13.0
 idna==3.10
 imbalanced-learn==0.13.0
-imblearn==0.0
-importlib_metadata @ file:///home/conda/feedstock_root/build_artifacts/importlib-metadata_1737420181517/work
-ipykernel @ file:///home/conda/feedstock_root/build_artifacts/ipykernel_1719845459717/work
-ipython @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_ipython_1741457126/work
-ipython_pygments_lexers @ file:///home/conda/feedstock_root/build_artifacts/ipython_pygments_lexers_1737123620466/work
-jedi @ file:///home/conda/feedstock_root/build_artifacts/jedi_1733300866624/work
 joblib==1.4.2
-jupyter_client @ file:///home/conda/feedstock_root/build_artifacts/jupyter_client_1733440914442/work
-jupyter_core @ file:///home/conda/feedstock_root/build_artifacts/jupyter_core_1727163409502/work
 kaggle==1.6.17
 keras==3.9.0
 kiwisolver==1.4.8
@@ -37,50 +23,24 @@ Markdown==3.7
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 matplotlib==3.10.1
-matplotlib-inline @ file:///home/conda/feedstock_root/build_artifacts/matplotlib-inline_1733416936468/work
 mdurl==0.1.2
 missingno==0.5.2
 ml-dtypes==0.4.1
 mpmath==1.3.0
 namex==0.0.8
-nest_asyncio @ file:///home/conda/feedstock_root/build_artifacts/nest-asyncio_1733325553580/work
 nltk==3.9.1
 numpy==2.0.2
-nvidia-cublas-cu12==12.5.3.2
-nvidia-cuda-cupti-cu12==12.5.82
-nvidia-cuda-nvcc-cu12==12.5.82
-nvidia-cuda-nvrtc-cu12==12.5.82
-nvidia-cuda-runtime-cu12==12.5.82
-nvidia-cudnn-cu12==9.3.0.75
-nvidia-cufft-cu12==11.2.3.61
-nvidia-curand-cu12==10.3.6.82
-nvidia-cusolver-cu12==11.6.3.83
-nvidia-cusparse-cu12==12.5.1.3
-nvidia-nccl-cu12==2.21.5
-nvidia-nvjitlink-cu12==12.5.82
-opt_einsum==3.4.0
+opt-einsum==3.4.0
 optree==0.14.1
-packaging @ file:///home/conda/feedstock_root/build_artifacts/packaging_1733203243479/work
 pandas==2.2.3
-parso @ file:///home/conda/feedstock_root/build_artifacts/parso_1733271261340/work
-pexpect @ file:///home/conda/feedstock_root/build_artifacts/pexpect_1733301927746/work
-pickleshare @ file:///home/conda/feedstock_root/build_artifacts/pickleshare_1733327343728/work
 pillow==11.1.0
-platformdirs @ file:///home/conda/feedstock_root/build_artifacts/platformdirs_1733232627818/work
 powerlaw==1.5
-prompt_toolkit @ file:///home/conda/feedstock_root/build_artifacts/prompt-toolkit_1737453357274/work
 protobuf==5.29.3
-psutil @ file:///croot/psutil_1736367091698/work
-ptyprocess @ file:///home/conda/feedstock_root/build_artifacts/ptyprocess_1733302279685/work/dist/ptyprocess-0.7.0-py2.py3-none-any.whl#sha256=92c32ff62b5fd8cf325bec5ab90d7be3d2a8ca8c8a3813ff487a8d2002630d1f
-pure_eval @ file:///home/conda/feedstock_root/build_artifacts/pure_eval_1733569405015/work
 pyaml==25.1.0
-Pygments @ file:///home/conda/feedstock_root/build_artifacts/pygments_1736243443484/work
 pyparsing==3.2.1
-python-dateutil @ file:///home/conda/feedstock_root/build_artifacts/python-dateutil_1733215673016/work
 python-slugify==8.0.4
 pytz==2025.1
 PyYAML==6.0.2
-pyzmq @ file:///croot/pyzmq_1734687138743/work
 regex==2024.11.6
 requests==2.32.3
 rich==13.9.4
@@ -88,26 +48,17 @@ scikit-learn==1.6.1
 scikit-optimize==0.10.2
 scipy==1.15.2
 seaborn==0.13.2
-setuptools==75.8.0
-six @ file:///home/conda/feedstock_root/build_artifacts/six_1733380938961/work
 sklearn-compat==0.1.3
-stack_data @ file:///home/conda/feedstock_root/build_artifacts/stack_data_1733569443808/work
 tensorboard==2.18.0
 tensorboard-data-server==0.7.2
 tensorflow==2.18.0
 termcolor==2.5.0
 text-unidecode==1.3
 threadpoolctl==3.5.0
-tornado @ file:///croot/tornado_1733960490606/work
 tqdm==4.67.1
-traitlets @ file:///home/conda/feedstock_root/build_artifacts/traitlets_1733367359838/work
-typing_extensions @ file:///home/conda/feedstock_root/build_artifacts/typing_extensions_1733188668063/work
 tzdata==2025.1
 ucimlrepo==0.0.7
 urllib3==2.3.0
-wcwidth @ file:///home/conda/feedstock_root/build_artifacts/wcwidth_1733231326287/work
 webencodings==0.5.1
 Werkzeug==3.1.3
-wheel==0.45.1
 wrapt==1.17.2
-zipp @ file:///home/conda/feedstock_root/build_artifacts/zipp_1732827521216/work


### PR DESCRIPTION
## Summary
- replace `requirements.txt` with pip-compatible package pins so the project installs cleanly

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement absl-py==2.1.0 due to proxy 403)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68afa2de203c8321a06e870234d75586