### PR TITLE
Add EPRDS paper methods and reproducible evaluation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,134 @@
 https://ieeexplore.ieee.org/document/11204481
 
-# ML-UQ-Review
+# ML-UQ-Review with EPRDS Extension
 
-Review and performance evaluation of uncertainty quantification in machine learning assisted measurements.
+Review and performance evaluation of uncertainty quantification in machine-learning-assisted measurements. The `eprds-extension` branch adds the complete uncertainty-method set used in the EPRDS study while retaining the original dataset, training, MC-dropout, evaluation, and plotting workflow.
 
 ## Environment setup
-1. Create and activate a Conda environment (either the base environment or a new one). For example, to create an isolated environment named `mluq`:
+
+1. Create and activate a Conda environment:
+
    ```bash
    conda create -n mluq python=3.10
    conda activate mluq
    ```
+
 2. Install the required packages:
+
    ```bash
    pip install -r requirements.txt
    ```
 
 ## Downloading datasets
-The project uses Kaggle to obtain benchmark datasets. To download them:
-1. Install and configure the Kaggle command line interface. Follow the [Kaggle API instructions](https://www.kaggle.com/docs/api) to place your `kaggle.json` credentials in `~/.kaggle/`.
-2. Run the downloader script:
+
+The project uses Kaggle to obtain benchmark datasets.
+
+1. Install and configure the Kaggle command-line interface. Place `kaggle.json` in `~/.kaggle/`.
+2. Run:
+
    ```bash
    python datasets/data_downloader.py
    ```
-   Each dataset will be extracted under `datasets/<name>`.
+
+Each dataset is extracted under `datasets/<name>`.
 
 ## Training models
-After the datasets are downloaded, train the corresponding models:
 
 ```bash
 bash train.sh
 ```
 
-This script iterates over every dataset and stores the trained model in its
-respective folder. Once training is complete, you can evaluate a dataset with
-`main.py` as described below.
+The script iterates over the configured datasets and stores each trained model in its corresponding dataset folder.
 
-## Running `main.py`
-`main.py` evaluates a trained model using MC Dropout and generates plots summarising uncertainty metrics.
+## Running the experiments
 
-Two ways to run it:
-- Using a predefined dataset abbreviation:
-  ```bash
-  python main.py --dataset mnist
-  ```
-  The script will automatically locate the model and test arrays inside `datasets/mnist/`.
-- Explicit paths to a model and test arrays:
-  ```bash
-  python main.py --model_path path/to/model.keras \
-                 --X_test_path path/to/X_test.npy \
-                 --y_test_path path/to/y_test.npy
-  ```
+Using a predefined dataset abbreviation:
 
-Output plots (PNG and EPS) are written to the corresponding dataset folder.
-In the same directory, a `*_results.json` file captures the arrays used to
-generate the figures. It stores the uncertainty bins (`u_lists`, `m_lists`,
-`c_lists`) and summaries of how each method differs from MP across ten
-classification metrics.
+```bash
+python main.py --dataset mnist
+```
 
-## Evaluating all datasets
-To run `main.py` for every dataset in a single command, use the helper script:
+Using explicit paths:
+
+```bash
+python main.py \
+  --model_path path/to/model.keras \
+  --X_test_path path/to/X_test.npy \
+  --y_test_path path/to/y_test.npy
+```
+
+To evaluate all configured datasets:
 
 ```bash
 bash evaluate.sh
 ```
 
-This will sequentially evaluate each dataset using its trained model.
+The evaluation uses MC dropout, calculates every uncertainty method listed below, builds uncertainty bins, evaluates accuracy/precision/recall/F1, and writes PNG, EPS, and JSON outputs to the corresponding dataset folder.
 
+## Implemented uncertainty methods
+
+| Code label | Paper notation / meaning | Prediction used |
+|---|---|---|
+| `MP` | Misclassification probability from the first pass | First-pass prediction |
+| `MP_Mean` | Misclassification probability from the mean predictive distribution | MC-mean prediction |
+| `Entropy` | Normalized categorical entropy from the first pass | First-pass prediction |
+| `M_E` | Mean of entropy over repeated observations | MC-mean prediction |
+| `E_M` | Entropy of the mean predictive distribution | MC-mean prediction |
+| `Max_E` | Maximum entropy among repeated observations | MC-mean prediction |
+| `DPkP` | Deviation of the probability of the stable predicted class; also called DPP in the earlier code | MC-mean prediction |
+| `EPR` | Mean entropy of predicted class versus all remaining classes | MC-mean prediction |
+| `EPRD` | Deviation of predicted-versus-rest entropy | MC-mean prediction |
+| `EPRDS` | Mean predicted-versus-rest entropy multiplied by normalized entropy deviation | MC-mean prediction |
+
+For `DPkP`, `EPR`, `EPRD`, and `EPRDS`, the important class is selected once as the class with the highest probability in the mean MC-dropout predictive distribution. The same class is then tracked across all stochastic observations.
+
+### EPRDS calculation
+
+For sample `i`, let `k_i` be the stable predicted class. For observation `t`, its predicted-versus-rest distribution is:
+
+```text
+[p_t(k_i), 1 - p_t(k_i)]
+```
+
+The binary entropy of this distribution is calculated for every observation. EPRDS is implemented as:
+
+```text
+EPRDS_i = mean_t(EPR_t,i) * minmax_i(std_t(EPR_t,i))
+```
+
+The deviation term is normalized across the evaluated dataset so the final values remain on the uncertainty scale used by the original experiment pipeline.
+
+The implementation is in `utils/uncertainty_quantification.py`. Paper-style aliases such as `M_E`, `E_M`, `Max_E`, `DPkP`, and `EPRDS` are exported directly.
+
+## Running numerical tests
+
+The tests do not require TensorFlow models or downloaded datasets:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+The tests verify output shape and range, the EPRDS composition rule, zero deviation for identical stochastic observations, binary-class consistency, and input validation.
+
+## Output files
+
+For each model, the dataset directory receives:
+
+- accuracy, precision, recall, F1, and uncertainty-count plots in PNG and EPS;
+- `<model>_results.json`, containing:
+  - raw uncertainty values for every method;
+  - binned accuracy curves (`u_lists`);
+  - binned precision/recall/F1 curves (`m_lists`);
+  - bin counts (`c_lists`);
+  - differences relative to MP (`diff_summary`).
 
 ## Directory overview
-- `datasets/` – dataset downloader and downloaded data. After running the downloader, subfolders such as `mnist` or `credit_score` will appear here. Evaluation results from `main.py` are also saved in these folders.
-- `models/` – pre-trained `.keras` models and example notebooks used during model development.
-- `utils/` – helper modules for argument parsing, data loading, inference, metrics and plotting.
-- `main.py` – entry point that performs MC Dropout inference and creates figures.
-- `requirements.txt` – Python package dependencies.
 
-Running `main.py` generates accuracy, precision/recall/F1, and count plots describing model uncertainty. Files are saved in the dataset directory used for evaluation.
+- `datasets/` — dataset downloader, downloaded data, trained models, and experiment outputs.
+- `models/` — model-development notebooks and supporting model files.
+- `utils/uncertainty_quantification.py` — baseline and EPRDS uncertainty methods.
+- `utils/metrics.py` — generic binning and evaluation for any method dictionary.
+- `utils/plotting.py` — dynamic plotting for all enabled methods.
+- `tests/` — numerical unit tests for the uncertainty implementations.
+- `main.py` — MC-dropout evaluation entry point.
+- `requirements.txt` — Python dependencies.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
-import numpy as np
-import os 
+import os
 
 from utils import (
     parse_args,
@@ -11,6 +10,9 @@ from utils import (
     mean_entropy,
     max_entropy,
     std_predicted_prob,
+    predicted_vs_rest_entropy,
+    predicted_vs_rest_entropy_deviation,
+    eprds,
     compute_truth_flags,
     build_bins_from_arrays,
     summarise_metric_diffs,
@@ -24,49 +26,72 @@ def main():
     model, X, y = load_data(
         args.model_path,
         args.X_test_path,
-        args.y_test_path
+        args.y_test_path,
     )
 
-    # If u have really limited VRAM u can set --batch_size 64 or others to fit ur GPU
+    # If VRAM is limited, use --batch_size 64 (or another smaller value).
     obs = run_mc_dropout(model, X, args.num_observations, args.batch_size)
 
-    # Predictions and Truth flags for observations
+    # Predictions and truth flags.
     preds0 = obs[0].argmax(axis=1)
     preds_mc = obs.mean(axis=0).argmax(axis=1)
     flags0 = compute_truth_flags(y, preds0)
     flags_mc = compute_truth_flags(y, preds_mc)
 
-
     mp, mp_mean = misclassification_probability(obs)
-    ent = entropy(obs)
-    mean_ent = mean_entropy(obs)
-    ent_mean = entropy_mean(obs)
-    max_ent = max_entropy(obs)
-    dpp = std_predicted_prob(obs)
 
+    uncertainty = {
+        "MP": mp,
+        "MP_Mean": mp_mean,
+        "Entropy": entropy(obs),
+        "M_E": mean_entropy(obs),
+        "E_M": entropy_mean(obs),
+        "Max_E": max_entropy(obs),
+        "DPkP": std_predicted_prob(obs),
+        "EPR": predicted_vs_rest_entropy(obs),
+        "EPRD": predicted_vs_rest_entropy_deviation(obs),
+        "EPRDS": eprds(obs),
+    }
+
+    # MP uses the first-pass prediction; repeated-observation methods use the
+    # stable prediction obtained from the MC-mean distribution.
+    prediction_by_method = {
+        name: (preds0 if name == "MP" else preds_mc)
+        for name in uncertainty
+    }
+    flags_by_method = {
+        name: (flags0 if name == "MP" else flags_mc)
+        for name in uncertainty
+    }
 
     u_lists, m_lists, c_lists = build_bins_from_arrays(
         y,
-        mp=mp, mp_mean=mp_mean, ent=ent, mean_ent=mean_ent, ent_mean=ent_mean, max_ent=max_ent, dpp=dpp,
-        preds0=preds0, preds_mc=preds_mc,
-        flags0=flags0, flags_mc=flags_mc,
-        slices=10
+        uncertainty=uncertainty,
+        predictions=prediction_by_method,
+        truth_flags=flags_by_method,
+        slices=10,
     )
 
-    # Summarise per-bin metric differences
     diff_summary = summarise_metric_diffs(u_lists, m_lists)
 
-    # 5.  Plot everything
     output_dir = os.path.join(
-        'datasets',
-        os.path.basename(os.path.dirname(args.model_path))
+        "datasets",
+        os.path.basename(os.path.dirname(args.model_path)),
     )
     prefix = os.path.splitext(os.path.basename(args.model_path))[0]
 
     plot_all(u_lists, m_lists, c_lists, output_dir, prefix)
     json_path = os.path.join(output_dir, f"{prefix}_results.json")
-    save_results_json(u_lists, m_lists, c_lists, diff_summary, json_path)
+    save_results_json(
+        u_lists,
+        m_lists,
+        c_lists,
+        diff_summary,
+        json_path,
+        uncertainty=uncertainty,
+    )
     print("Done.")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_uncertainty_quantification.py
+++ b/tests/test_uncertainty_quantification.py
@@ -1,0 +1,81 @@
+import unittest
+
+import numpy as np
+
+from utils.uncertainty_quantification import (
+    DPkP,
+    E_M,
+    EPR,
+    EPRD,
+    EPRDS,
+    M_E,
+    Max_E,
+    entropy,
+    misclassification_probability,
+)
+
+
+class UncertaintyQuantificationTests(unittest.TestCase):
+    def setUp(self):
+        # Four stochastic observations, three samples, three classes.
+        self.obs = np.array(
+            [
+                [[0.80, 0.10, 0.10], [0.40, 0.35, 0.25], [0.10, 0.20, 0.70]],
+                [[0.75, 0.15, 0.10], [0.36, 0.39, 0.25], [0.15, 0.15, 0.70]],
+                [[0.85, 0.10, 0.05], [0.45, 0.30, 0.25], [0.10, 0.25, 0.65]],
+                [[0.78, 0.12, 0.10], [0.34, 0.41, 0.25], [0.12, 0.18, 0.70]],
+            ],
+            dtype=float,
+        )
+
+    def test_every_method_returns_one_finite_score_per_sample(self):
+        mp, mp_mean = misclassification_probability(self.obs)
+        methods = [
+            mp,
+            mp_mean,
+            entropy(self.obs),
+            M_E(self.obs),
+            E_M(self.obs),
+            Max_E(self.obs),
+            DPkP(self.obs),
+            EPR(self.obs),
+            EPRD(self.obs),
+            EPRDS(self.obs),
+        ]
+        for values in methods:
+            self.assertEqual(values.shape, (3,))
+            self.assertTrue(np.all(np.isfinite(values)))
+            self.assertTrue(np.all(values >= 0.0))
+            self.assertTrue(np.all(values <= 1.0 + 1e-12))
+
+    def test_eprds_is_mean_epr_scaled_by_normalized_deviation(self):
+        epr = EPR(self.obs)
+        deviation = EPRD(self.obs)
+        np.testing.assert_allclose(EPRDS(self.obs), epr * deviation)
+
+    def test_no_stochastic_variation_gives_zero_deviation_methods(self):
+        deterministic = np.repeat(self.obs[:1], repeats=5, axis=0)
+        np.testing.assert_allclose(DPkP(deterministic), 0.0, atol=1e-12)
+        np.testing.assert_allclose(EPRD(deterministic), 0.0, atol=1e-12)
+        np.testing.assert_allclose(EPRDS(deterministic), 0.0, atol=1e-12)
+
+    def test_binary_class_epr_matches_categorical_entropy_per_observation(self):
+        binary = np.array(
+            [
+                [[0.8, 0.2], [0.55, 0.45]],
+                [[0.7, 0.3], [0.60, 0.40]],
+            ]
+        )
+        expected = np.mean(
+            [entropy(binary[index : index + 1]) for index in range(binary.shape[0])],
+            axis=0,
+        )
+        np.testing.assert_allclose(EPR(binary), expected)
+
+    def test_invalid_shape_raises_clear_error(self):
+        with self.assertRaises(ValueError):
+            EPRDS(np.ones((3, 4)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,7 +1,25 @@
 from .arguments import parse_args
 from .build_model import load_data
 from .inference import run_mc_dropout, compute_truth_flags
-from .uncertainty_quantification import misclassification_probability, entropy, entropy_mean, mean_entropy, max_entropy, std_predicted_prob
+from .uncertainty_quantification import (
+    misclassification_probability,
+    entropy,
+    entropy_mean,
+    mean_entropy,
+    max_entropy,
+    std_predicted_prob,
+    predicted_vs_rest_entropy,
+    predicted_vs_rest_entropy_deviation,
+    eprds,
+    M_E,
+    E_M,
+    Max_E,
+    DPkP,
+    DPP,
+    EPR,
+    EPRD,
+    EPRDS,
+)
 from .metrics import (
     build_bins_from_arrays,
     summarise_metric_diffs,

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,190 +1,168 @@
-# ---------------------------------------------------------------------
-#  Binning helpers (vectorised, safe for empty bins)
-# ---------------------------------------------------------------------
-import numpy as np
-from sklearn.metrics import (
-    precision_score,
-    recall_score,
-    f1_score
-)
 import json
 
-# def cal_bin(uc, truth_flags, slices=10, return_rate=True):
-#     """Per-bin accuracy *or* count, NaN for empty bins."""
-#     edges   = np.linspace(0, 1, slices + 1)
-#     results = []
-#     for k in range(slices):
-#         sel = [truth_flags[i] for i, u in enumerate(uc)
-#                if edges[k] <= u < edges[k + 1]]
-#         if return_rate:
-#             results.append(sel.count('T') / len(sel) if sel else np.nan)
-#         else:
-#             results.append(len(sel))
-#     return np.asarray(results, dtype=float)
+import numpy as np
+from sklearn.metrics import f1_score, precision_score, recall_score
+
 
 def cal_bin(uc, truth_flags, slices=10, return_rate=True):
-    """Per-bin accuracy *or* count, NaN for empty bins."""
-    edges   = np.linspace(0, 1, slices + 1)
+    """Compute per-bin accuracy or count; empty accuracy bins are NaN."""
+    uc = np.asarray(uc)
+    edges = np.linspace(0, 1, slices + 1)
     results = []
-    for k in range(slices):
-        if k == slices - 1:
-            sel = [truth_flags[i] for i, u in enumerate(uc)
-                   if edges[k] <= u <= edges[k + 1]]
+    for index in range(slices):
+        if index == slices - 1:
+            mask = (uc >= edges[index]) & (uc <= edges[index + 1])
         else:
-            sel = [truth_flags[i] for i, u in enumerate(uc)
-                   if edges[k] <= u < edges[k + 1]]
+            mask = (uc >= edges[index]) & (uc < edges[index + 1])
+        selected = [truth_flags[i] for i in np.where(mask)[0]]
         if return_rate:
-            results.append(sel.count('T') / len(sel) if sel else np.nan)
+            results.append(selected.count("T") / len(selected) if selected else np.nan)
         else:
-            results.append(len(sel))
+            results.append(len(selected))
     return np.asarray(results, dtype=float)
 
 
 def cal_bin_counts(uc, truth_flags, slices=10):
     return cal_bin(uc, truth_flags, slices, return_rate=False)
 
+
 def grouper(uc, truth, preds, slices=10):
-    """Return *lists* of y_true / y_pred arrays, one per bin."""
+    """Group ground-truth and predicted labels by uncertainty bin."""
+    uc = np.asarray(uc)
     edges = np.linspace(0, 1, slices + 1)
-    y_tr, y_pr = [], []
-    for k in range(slices):
-        idx = np.where((uc >= edges[k]) & (uc < edges[k + 1]))[0]
-        y_tr.append(truth[idx])
-        y_pr.append(preds[idx])
-    return y_tr, y_pr
+    y_true_bins, y_pred_bins = [], []
+    for index in range(slices):
+        if index == slices - 1:
+            mask = (uc >= edges[index]) & (uc <= edges[index + 1])
+        else:
+            mask = (uc >= edges[index]) & (uc < edges[index + 1])
+        y_true_bins.append(truth[mask])
+        y_pred_bins.append(preds[mask])
+    return y_true_bins, y_pred_bins
+
 
 def cal_bin_others(y_true_bins, preds_bins):
-    """Nine metrics (P/R/F1 × macro/micro/weighted) for every bin."""
-    out = np.full((9, len(y_true_bins)), np.nan)          # default NaN
-    for i in range(len(y_true_bins)):
-        if len(y_true_bins[i]) == 0:
+    """Precision, recall, and F1 (macro/micro/weighted) for every bin."""
+    output = np.full((9, len(y_true_bins)), np.nan)
+    for index, (truth, pred) in enumerate(zip(y_true_bins, preds_bins)):
+        if len(truth) == 0:
             continue
-        out[0, i] = precision_score(y_true_bins[i], preds_bins[i], average='macro')
-        out[1, i] = precision_score(y_true_bins[i], preds_bins[i], average='micro')
-        out[2, i] = precision_score(y_true_bins[i], preds_bins[i], average='weighted')
-        out[3, i] = recall_score   (y_true_bins[i], preds_bins[i], average='macro')
-        out[4, i] = recall_score   (y_true_bins[i], preds_bins[i], average='micro')
-        out[5, i] = recall_score   (y_true_bins[i], preds_bins[i], average='weighted')
-        out[6, i] = f1_score       (y_true_bins[i], preds_bins[i], average='macro')
-        out[7, i] = f1_score       (y_true_bins[i], preds_bins[i], average='micro')
-        out[8, i] = f1_score       (y_true_bins[i], preds_bins[i], average='weighted')
-    return out
-# ---------------------------------------------------------------------
-#  One-stop function that prepares EVERYTHING for plot_all()
-# ---------------------------------------------------------------------
-# utils.py  (append near the other helpers)
-# -------------------------------------------
+        kwargs = {"zero_division": 0}
+        output[0, index] = precision_score(truth, pred, average="macro", **kwargs)
+        output[1, index] = precision_score(truth, pred, average="micro", **kwargs)
+        output[2, index] = precision_score(truth, pred, average="weighted", **kwargs)
+        output[3, index] = recall_score(truth, pred, average="macro", **kwargs)
+        output[4, index] = recall_score(truth, pred, average="micro", **kwargs)
+        output[5, index] = recall_score(truth, pred, average="weighted", **kwargs)
+        output[6, index] = f1_score(truth, pred, average="macro", **kwargs)
+        output[7, index] = f1_score(truth, pred, average="micro", **kwargs)
+        output[8, index] = f1_score(truth, pred, average="weighted", **kwargs)
+    return output
+
+
 def build_bins_from_arrays(
     y_onehot,
     *,
-    mp, mp_mean, ent, mean_ent, ent_mean, max_ent, dpp,
-    preds0, preds_mc,
-    flags0, flags_mc,
-    slices: int = 10
+    uncertainty,
+    predictions,
+    truth_flags,
+    slices=10,
 ):
+    """Build accuracy, classification-metric, and count curves.
+
+    Parameters are dictionaries keyed by method name. This generic interface
+    allows new uncertainty methods to be added without editing this function.
     """
-    Consume the already-computed uncertainty arrays + flags/preds
-    and return the three dicts that `plot_all()` expects.
-    """
-    # --- accuracy curves & instance counts --------------------------
+    method_names = list(uncertainty)
+    if set(method_names) != set(predictions) or set(method_names) != set(truth_flags):
+        raise ValueError("uncertainty, predictions, and truth_flags must share keys")
+
     u_lists = {
-        'MP'        : cal_bin(mp,        flags0, slices),
-        'MP_Mean'     : cal_bin(mp_mean,     flags_mc, slices),
-        'Entropy'   : cal_bin(ent,       flags0, slices),
-        'Mean_Entropy'   : cal_bin(mean_ent,       flags_mc, slices),
-        'Entropy_Mean': cal_bin(ent_mean,    flags_mc, slices),
-        'Max_Entropy'   : cal_bin(max_ent,       flags_mc, slices),
-        'DPP'       : cal_bin(dpp,       flags_mc, slices),
+        name: cal_bin(uncertainty[name], truth_flags[name], slices)
+        for name in method_names
     }
     c_lists = {
-        'MP'        : cal_bin_counts(mp,        flags0, slices),
-        'MP_Mean'     : cal_bin_counts(mp_mean,     flags_mc, slices),
-        'Entropy'   : cal_bin_counts(ent,       flags0, slices),
-        'Mean_Entropy'   : cal_bin_counts(mean_ent,       flags_mc, slices),
-        'Entropy_Mean': cal_bin_counts(ent_mean,    flags_mc, slices),
-        'Max_Entropy'   : cal_bin_counts(max_ent,       flags_mc, slices),
-        'DPP'       : cal_bin_counts(dpp,       flags_mc, slices),
+        name: cal_bin_counts(uncertainty[name], truth_flags[name], slices)
+        for name in method_names
     }
 
-    # --- precision / recall / F1 curves -----------------------------
-    gt_labels = y_onehot.argmax(axis=1)           # shape (N,)
-    m_lists   = {}
-    for name, (u_arr, preds_arr) in {
-        'MP'        : (mp,        preds0),
-        'MP_Mean'     : (mp_mean,     preds_mc),
-        'Entropy'   : (ent,       preds0),
-        'Mean_Entropy'   : (mean_ent,      preds_mc),
-        'Entropy_Mean': (ent_mean,   preds_mc),
-        'Max_Entropy'   : (max_ent,     preds_mc),
-        'DPP'       : (dpp,       preds_mc)
-    }.items():
-        y_true_bins, y_pred_bins = grouper(u_arr, gt_labels, preds_arr, slices)
-        m_lists[name] = cal_bin_others(y_true_bins, y_pred_bins)
+    ground_truth = np.asarray(y_onehot).argmax(axis=1)
+    m_lists = {}
+    for name in method_names:
+        truth_bins, pred_bins = grouper(
+            uncertainty[name], ground_truth, predictions[name], slices
+        )
+        m_lists[name] = cal_bin_others(truth_bins, pred_bins)
 
     return u_lists, m_lists, c_lists
 
 
-# ---------------------------------------------------------------------
-#  Additional helpers: JSON output and diff summaries
-# ---------------------------------------------------------------------
-
-
-def summarise_metric_diffs(u_lists, m_lists, threshold=0.9):
-    """Summarise per-bin metric differences against MP."""
+def summarise_metric_diffs(u_lists, m_lists, baseline="MP", threshold=0.9):
+    """Summarize per-bin metric differences against a baseline method."""
+    if baseline not in u_lists:
+        raise KeyError(f"baseline {baseline!r} is not present")
 
     metric_names = [
         "Accuracy",
-        "Macro Precision", "Micro Precision", "Weighted Precision",
-        "Macro Recall", "Micro Recall", "Weighted Recall",
-        "Macro F1", "Micro F1", "Weighted F1",
+        "Macro Precision",
+        "Micro Precision",
+        "Weighted Precision",
+        "Macro Recall",
+        "Micro Recall",
+        "Weighted Recall",
+        "Macro F1",
+        "Micro F1",
+        "Weighted F1",
     ]
 
-    base_acc = np.asarray(u_lists['MP'])
-    base_m   = np.asarray(m_lists['MP'])
-
+    baseline_accuracy = np.asarray(u_lists[baseline])
+    baseline_metrics = np.asarray(m_lists[baseline])
     summaries = {}
-    for method, acc in u_lists.items():
-        if method == 'MP':
+
+    for method, accuracy in u_lists.items():
+        if method == baseline:
             continue
-        acc = np.asarray(acc)
-        metr = np.asarray(m_lists[method])
+        accuracy = np.asarray(accuracy)
+        metrics = np.asarray(m_lists[method])
+        differences = np.vstack(
+            [accuracy - baseline_accuracy, metrics - baseline_metrics]
+        )
 
-        diffs = np.vstack([acc - base_acc, metr - base_m])
         summary = {}
-        for name, arr in zip(metric_names, diffs):
-            arr = np.where(np.isnan(arr), 0.0, arr)
-            avg_all = float(np.mean(arr)) if arr.size else float('nan')
-            max_all = float(np.max(arr)) if arr.size else float('nan')
-            mask = acc > threshold
-            if mask.any():
-                avg90 = float(np.mean(arr[mask]))
-            else:
-                avg90 = float('nan')
+        for name, values in zip(metric_names, differences):
+            finite_values = values[np.isfinite(values)]
+            high_accuracy = values[(accuracy > threshold) & np.isfinite(values)]
             summary[name] = {
-                'avg90': avg90,
-                'avg_all': avg_all,
-                'max_all': max_all,  
+                "avg90": float(np.mean(high_accuracy)) if high_accuracy.size else None,
+                "avg_all": float(np.mean(finite_values)) if finite_values.size else None,
+                "max_all": float(np.max(finite_values)) if finite_values.size else None,
             }
-
         summaries[method] = summary
-
     return summaries
 
-def save_results_json(u_lists, m_lists, c_lists, diff_summary, out_path):
-    """Save arrays and metric comparisons to a JSON file."""
 
-    def conv(d):
-        return {k: np.asarray(v).tolist() for k, v in d.items()}
+def save_results_json(
+    u_lists,
+    m_lists,
+    c_lists,
+    diff_summary,
+    out_path,
+    *,
+    uncertainty=None,
+):
+    """Save binned curves, raw uncertainty arrays, and comparisons to JSON."""
+
+    def convert(mapping):
+        return {key: np.asarray(value).tolist() for key, value in mapping.items()}
 
     data = {
-        'u_lists': conv(u_lists),
-        'm_lists': conv(m_lists),
-        'c_lists': conv(c_lists),
-        'diff_summary': diff_summary,
+        "u_lists": convert(u_lists),
+        "m_lists": convert(m_lists),
+        "c_lists": convert(c_lists),
+        "diff_summary": diff_summary,
     }
+    if uncertainty is not None:
+        data["uncertainty"] = convert(uncertainty)
 
-
-    with open(out_path, 'w') as f:
-        json.dump(data, f, indent=2)
-
-
+    with open(out_path, "w", encoding="utf-8") as file:
+        json.dump(data, file, indent=2, allow_nan=False)

--- a/utils/plotting.py
+++ b/utils/plotting.py
@@ -1,187 +1,133 @@
 import os
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
 
-# ---------------------------------------------------------------------
-# Helper: consistent colour / style palette
-# ---------------------------------------------------------------------
-_DARK_COLS   = ['#444444', '#8B4513', '#2E8B57', '#483D8B', '#556B2F',
-                '#8B0000', '#006666']
-_LINESTYLES  = ['-', '--', '-.', ':', '-', '--', '-']
-_MARKERS     = ['o', 's', '^', 'D', 'p', 'X', 'h']
-_HATCHES     = ['/', '\\', 'o', '+', '*', '.', 'x']
+_DARK_COLS = [
+    "#444444",
+    "#8B4513",
+    "#2E8B57",
+    "#483D8B",
+    "#556B2F",
+    "#8B0000",
+    "#006666",
+    "#1F4E79",
+    "#7F6000",
+    "#7030A0",
+]
+_LINESTYLES = ["-", "--", "-.", ":"]
+_MARKERS = ["o", "s", "^", "D", "p", "X", "h", "v", "<", ">"]
+_HATCHES = ["/", "\\", "o", "+", "*", ".", "x", "-", "|", "O"]
 
 
-# ---------------------------------------------------------------------
-# 1) Generic 2-D line plot
-# ---------------------------------------------------------------------
 def plot_metric(x, lines, labels, xlabel, ylabel, outpath_png, outpath_eps):
-    """
-    Draws a single panel (line plot) with the *exact* visual style
-    used in the long, hand-written code block, but treats 'Ideal'
-    specially (black, dotted, no markers).
-    """
-    plt.figure(figsize=(6, 4.5), dpi=100)
-    plt.xlabel(xlabel, fontsize=20)
-    plt.ylabel(ylabel, fontsize=20)
-
-    # axis limits, ticks, grid
-    plt.xlim(0.1, 1)
+    """Draw one uncertainty-versus-performance line plot."""
+    plt.figure(figsize=(7.5, 5.2), dpi=100)
+    plt.xlabel(xlabel, fontsize=18)
+    plt.ylabel(ylabel, fontsize=18)
+    plt.xlim(0.1, 1.0)
     plt.ylim(0, 1)
-    plt.xticks(np.arange(0.1, 1.1, 0.1), fontsize=15)
-    plt.yticks(np.arange(0, 1.1, 0.1), fontsize=15)
-    plt.grid(True, which='both', linestyle=':', linewidth=0.5, color='gray')
-    plt.axhline(y=0.9, color='gray', linestyle='--', linewidth=1)
+    plt.xticks(np.arange(0.1, 1.1, 0.1), fontsize=12)
+    plt.yticks(np.arange(0, 1.1, 0.1), fontsize=12)
+    plt.grid(True, which="both", linestyle=":", linewidth=0.5, color="gray")
+    plt.axhline(y=0.9, color="gray", linestyle="--", linewidth=1)
 
-    for i, (y, lab) in enumerate(zip(lines, labels)):
-        if lab == 'Ideal Line':
-            # special styling for the ideal line
-            plt.plot(
-                x, y,
-                color='black',
-                linestyle='--',
-                linewidth=2,
-                label=lab
-            )
-        else:
-            plt.plot(
-                x, y,
-                color=_DARK_COLS[i % len(_DARK_COLS)],
-                linestyle=_LINESTYLES[i % len(_LINESTYLES)],
-                marker=_MARKERS[i % len(_MARKERS)],
-                markersize=10,
-                linewidth=2,
-                label=lab
-            )
+    for index, (values, label) in enumerate(zip(lines, labels)):
+        plt.plot(
+            x,
+            values,
+            color=_DARK_COLS[index % len(_DARK_COLS)],
+            linestyle=_LINESTYLES[index % len(_LINESTYLES)],
+            marker=_MARKERS[index % len(_MARKERS)],
+            markersize=7,
+            linewidth=1.8,
+            label=label,
+        )
 
-    plt.legend(loc='lower left', fontsize=15, ncol=2)
+    plt.legend(loc="best", fontsize=10, ncol=2)
     plt.tight_layout()
-    plt.savefig(outpath_png, bbox_inches='tight')
-    plt.savefig(outpath_eps, bbox_inches='tight')
+    plt.savefig(outpath_png, bbox_inches="tight")
+    plt.savefig(outpath_eps, bbox_inches="tight")
     plt.close()
 
 
-
-# ---------------------------------------------------------------------
-# 2) Produce *all* figures in one call
-# ---------------------------------------------------------------------
 def plot_all(u_lists, m_lists, counts, output_dir, prefix):
-    """
-    Parameters
-    ----------
-    u_lists : dict[str, (10,)]           – accuracy curves
-              keys expected: 'MP', 'MP_Mean', 'Entropy', 'Mean_Entropy', 'Entropy_Mean', 'Max_Entropy', 'DPP'
-    m_lists : dict[str, (9, 10)]         – metric curves
-              row-order: [Pre-Mac, Pre-Mic, Pre-Wei,
-                          Rec-Mac, Rec-Mic, Rec-Wei,
-                          F1-Mac,  F1-Mic,  F1-Wei]
-    counts  : dict[str, (10,)]           – per-bin instance counts
-    output_dir : str
-    prefix     : str – file-name prefix without extension
-    """
+    """Create all performance and count figures for the supplied methods."""
     os.makedirs(output_dir, exist_ok=True)
-    x_vals = np.arange(0.1, 1.1, 0.1)          # same bin mid-points
+    order = list(u_lists)
+    x_values = np.arange(0.1, 1.1, 0.1)
 
-    order = ['MP', 'MP_Mean', 'Entropy', 'Mean_Entropy', 'Entropy_Mean', 'Max_Entropy', 'DPP']
-
-    # Compute ideal reference line: y = [0.95, 0.85, …, 0.05]
-    #ideal_y = [0.95 - 0.1 * i for i in range(len(x_vals))]
-
-    # ---- Accuracy (with Ideal) ------------------------------------
-    # plot_metric(
-    #     x_vals,
-    #     [u_lists[k] for k in order] + [ideal_y],
-    #     order + ['Ideal Line'],
-    #     'Uncertainty',
-    #     'Accuracy',
-    #     os.path.join(output_dir, f"{prefix}_acc.png"),
-    #     os.path.join(output_dir, f"{prefix}_acc.eps")
-    # )
     plot_metric(
-        x_vals,
-        [u_lists[k] for k in order],
+        x_values,
+        [u_lists[key] for key in order],
         order,
-        'Uncertainty',
-        'Accuracy',
+        "Uncertainty",
+        "Accuracy",
         os.path.join(output_dir, f"{prefix}_acc.png"),
-        os.path.join(output_dir, f"{prefix}_acc.eps")
+        os.path.join(output_dir, f"{prefix}_acc.eps"),
     )
-    plt.close()
 
-    # ---- Precision / Recall / F1 (macro, micro, weighted), all with Ideal -----------
     metric_groups = [
-        ('pre', 0, 'Macro Precision'),
-        ('pre', 1, 'Micro Precision'),
-        ('pre', 2, 'Weighted Precision'),
-        ('rec', 3, 'Macro Recall'),
-        ('rec', 4, 'Micro Recall'),
-        ('rec', 5, 'Weighted Recall'),
-        ('f1',  6, 'Macro F1 Score'),
-        ('f1',  7, 'Micro F1 Score'),
-        ('f1',  8, 'Weighted F1 Score')
+        ("pre", 0, "Macro Precision"),
+        ("pre", 1, "Micro Precision"),
+        ("pre", 2, "Weighted Precision"),
+        ("rec", 3, "Macro Recall"),
+        ("rec", 4, "Micro Recall"),
+        ("rec", 5, "Weighted Recall"),
+        ("f1", 6, "Macro F1 Score"),
+        ("f1", 7, "Micro F1 Score"),
+        ("f1", 8, "Weighted F1 Score"),
     ]
-
-    for tag, idx, ylabel in metric_groups:
-        # curves = [m_lists[k][idx] for k in order] + [ideal_y]
-        # labels = order + ['Ideal Line']
-        curves = [m_lists[k][idx] for k in order]
-        labels = order
+    suffixes = ["mac", "mic", "wei"]
+    for tag, index, ylabel in metric_groups:
         plot_metric(
-            x_vals,
-            curves,
-            labels,
-            'Uncertainty',
+            x_values,
+            [m_lists[key][index] for key in order],
+            order,
+            "Uncertainty",
             ylabel,
-            os.path.join(output_dir, f"{prefix}_{tag}_{['mac','mic','wei'][idx%3]}.png"),
-            os.path.join(output_dir, f"{prefix}_{tag}_{['mac','mic','wei'][idx%3]}.eps")
+            os.path.join(
+                output_dir,
+                f"{prefix}_{tag}_{suffixes[index % 3]}.png",
+            ),
+            os.path.join(
+                output_dir,
+                f"{prefix}_{tag}_{suffixes[index % 3]}.eps",
+            ),
         )
-        plt.close()
 
-    # ---- BAR plot: instance counts (styled like reference) ------------
-    max_len   = len(next(iter(counts.values())))
-    x_bar     = np.arange(0.1, 0.1 * max_len + 0.1, 0.1)
-    bar_width = 0.015  # Same as your reference
-
-    plt.figure(figsize=(8, 5), dpi=100)
-    plt.xlabel('Uncertainty Bins', fontsize=20)
-    plt.ylabel('Count', fontsize=20)
-    plt.xticks(x_bar, fontsize=15, rotation=45)
-    plt.yticks(fontsize=15)
-    plt.grid(True, which='both', linestyle=':', linewidth=0.5, color='gray')
-
-    # Compute max y
-    ymax = max(max(c) for c in counts.values())
-    plt.ylim(0, ymax + 1)
-
-    # Plot bars with symmetric spacing
-    bars = []
+    max_length = len(next(iter(counts.values())))
+    x_bar = np.arange(0.1, 0.1 * max_length + 0.1, 0.1)
     total_methods = len(order)
-    offsets = np.linspace(-2.5, 2.5, total_methods) * bar_width
+    bar_width = min(0.08 / max(total_methods, 1), 0.015)
+    offsets = (
+        np.arange(total_methods) - (total_methods - 1) / 2
+    ) * bar_width
 
-    for i, (method, offset) in enumerate(zip(order, offsets)):
-        bars.append(
-            plt.bar(
-                x_bar + offset,
-                counts[method],
-                width=bar_width,
-                color=_DARK_COLS[i % len(_DARK_COLS)],
-                hatch=_HATCHES[i % len(_HATCHES)],
-                edgecolor='black',
-                label=method
-            )
+    plt.figure(figsize=(9, 5.5), dpi=100)
+    plt.xlabel("Uncertainty Bins", fontsize=18)
+    plt.ylabel("Count", fontsize=18)
+    plt.xticks(x_bar, fontsize=12, rotation=45)
+    plt.yticks(fontsize=12)
+    plt.grid(True, which="both", linestyle=":", linewidth=0.5, color="gray")
+
+    for index, (method, offset) in enumerate(zip(order, offsets)):
+        plt.bar(
+            x_bar + offset,
+            counts[method],
+            width=bar_width,
+            color=_DARK_COLS[index % len(_DARK_COLS)],
+            hatch=_HATCHES[index % len(_HATCHES)],
+            edgecolor="black",
+            label=method,
         )
 
-    # Legend inside top right
-    plt.legend(
-        handles=bars,
-        loc='upper right',
-        fontsize=15,
-        ncol=2
-    )
-
-    # Layout & save
+    plt.legend(loc="best", fontsize=9, ncol=2)
     plt.tight_layout()
-    for ext in ['png', 'eps']:
-        plt.savefig(os.path.join(output_dir, f"{prefix}_count.{ext}"),
-                    format=ext, bbox_inches='tight')
+    for extension in ("png", "eps"):
+        plt.savefig(
+            os.path.join(output_dir, f"{prefix}_count.{extension}"),
+            format=extension,
+            bbox_inches="tight",
+        )
     plt.close()

--- a/utils/uncertainty_quantification.py
+++ b/utils/uncertainty_quantification.py
@@ -1,46 +1,166 @@
-# metrics.py
+"""Uncertainty-quantification methods for classification with MC dropout.
+
+All functions accept ``obs`` with shape ``(T, N, C)`` where ``T`` is the
+number of stochastic observations, ``N`` is the number of samples, and ``C``
+is the number of classes. Each function returns one uncertainty value per
+sample.
+
+The module keeps the original ML-UQ-Review method names and adds the methods
+used in the EPRDS paper. Paper-style aliases are provided for M_E, E_M, and
+Max_E so the implementation can be mapped directly to the manuscript.
+"""
+
+from __future__ import annotations
+
 import numpy as np
 
-def misclassification_probability(obs):
-    # obs: (num_obs, N, C)
-    baseline = obs[0]
-    argmax0 = baseline.argmax(axis=1)
-    mp = 1 - baseline[np.arange(len(argmax0)), argmax0]
-    mc_mean = obs.mean(axis=0)
-    argmax_mc = mc_mean.argmax(axis=1)
-    mp_mc = 1 - mc_mean[np.arange(len(argmax_mc)), argmax_mc]
-    return mp, mp_mc
+_EPS = np.finfo(np.float64).eps
 
-def entropy(obs):
-    base = obs.shape[2]
-    p = obs[0]
-    ent = -(p * np.log(p) / np.log(base)).sum(axis=1)
-    return ent
 
-def entropy_mean(obs):
-    base = obs.shape[2]
-    mc_mean = obs.mean(axis=0)
-    ent_mean = -(mc_mean * np.log(mc_mean) / np.log(base)).sum(axis=1)
-    return ent_mean
+def _validate_observations(obs: np.ndarray) -> np.ndarray:
+    """Return finite, normalized probabilities with shape ``(T, N, C)``."""
+    arr = np.asarray(obs, dtype=np.float64)
+    if arr.ndim != 3:
+        raise ValueError(f"obs must have shape (T, N, C), received {arr.shape}")
+    if min(arr.shape) < 1 or arr.shape[2] < 2:
+        raise ValueError("obs must contain at least one pass, one sample, and two classes")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError("obs contains NaN or infinite values")
+    if np.any(arr < 0):
+        raise ValueError("class probabilities cannot be negative")
 
-def mean_entropy(obs):
-    base = obs.shape[2]
-    # entropy per draw for each sample: (num_obs, N)
-    ent_per_draw = -(obs * np.log(obs) / np.log(base)).sum(axis=2)
-    # mean over draws: (N,)
-    mean_ent = ent_per_draw.mean(axis=0)
-    return mean_ent
+    totals = arr.sum(axis=2, keepdims=True)
+    if np.any(totals <= 0):
+        raise ValueError("class probabilities must have a positive sum")
+    arr = arr / totals
+    return np.clip(arr, _EPS, 1.0)
 
-def max_entropy(obs):
-    base = obs.shape[2]
-    # entropy per draw for each sample: (num_obs, N)
-    ent_per_draw = -(obs * np.log(obs) / np.log(base)).sum(axis=2)
-    # mean over draws: (N,)
-    max_ent = ent_per_draw.max(axis=0)
-    return max_ent
 
-def std_predicted_prob(obs):
-    preds_mc = obs.mean(axis=0).argmax(axis=1)
-    stds = obs[:, np.arange(obs.shape[1]), preds_mc].std(axis=0)
-    # normalize
-    return (stds - stds.min()) / (stds.max() - stds.min())
+def _minmax(values: np.ndarray) -> np.ndarray:
+    """Min-max normalize an array without producing NaN for constant input."""
+    values = np.asarray(values, dtype=np.float64)
+    minimum = values.min()
+    span = values.max() - minimum
+    if span <= _EPS:
+        return np.zeros_like(values)
+    return (values - minimum) / span
+
+
+def _categorical_entropy(probabilities: np.ndarray) -> np.ndarray:
+    """Normalized categorical entropy along the final axis."""
+    classes = probabilities.shape[-1]
+    return -(probabilities * np.log(probabilities) / np.log(classes)).sum(axis=-1)
+
+
+def _binary_entropy(probability: np.ndarray) -> np.ndarray:
+    """Binary entropy of predicted class versus all remaining classes."""
+    p = np.clip(np.asarray(probability, dtype=np.float64), _EPS, 1.0 - _EPS)
+    return -(p * np.log2(p) + (1.0 - p) * np.log2(1.0 - p))
+
+
+def _stable_predicted_class(obs: np.ndarray) -> np.ndarray:
+    """Predicted class selected from the mean of the stochastic observations."""
+    return obs.mean(axis=0).argmax(axis=1)
+
+
+def _predicted_class_probabilities(obs: np.ndarray) -> np.ndarray:
+    """Return p(y_hat|x) in every observation, with shape ``(T, N)``."""
+    predicted = _stable_predicted_class(obs)
+    return obs[:, np.arange(obs.shape[1]), predicted]
+
+
+def misclassification_probability(obs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return single-pass MP and MC-mean MP."""
+    arr = _validate_observations(obs)
+
+    baseline = arr[0]
+    baseline_class = baseline.argmax(axis=1)
+    mp = 1.0 - baseline[np.arange(len(baseline_class)), baseline_class]
+
+    mean_probability = arr.mean(axis=0)
+    mean_class = mean_probability.argmax(axis=1)
+    mp_mean = 1.0 - mean_probability[np.arange(len(mean_class)), mean_class]
+    return mp, mp_mean
+
+
+def entropy(obs: np.ndarray) -> np.ndarray:
+    """Entropy from the first deterministic/baseline observation."""
+    return _categorical_entropy(_validate_observations(obs)[0])
+
+
+def entropy_mean(obs: np.ndarray) -> np.ndarray:
+    """E_M: entropy of the mean class-probability vector."""
+    arr = _validate_observations(obs)
+    return _categorical_entropy(arr.mean(axis=0))
+
+
+def mean_entropy(obs: np.ndarray) -> np.ndarray:
+    """M_E: mean entropy across stochastic observations."""
+    arr = _validate_observations(obs)
+    return _categorical_entropy(arr).mean(axis=0)
+
+
+def max_entropy(obs: np.ndarray) -> np.ndarray:
+    """Max_E: maximum entropy among stochastic observations."""
+    arr = _validate_observations(obs)
+    return _categorical_entropy(arr).max(axis=0)
+
+
+def std_predicted_prob(obs: np.ndarray, normalize: bool = True) -> np.ndarray:
+    """DPP/DPkP: deviation of the stable predicted-class probability.
+
+    The important class is selected once from the mean predictive distribution,
+    and the standard deviation of that same class probability is measured over
+    all stochastic observations.
+    """
+    arr = _validate_observations(obs)
+    deviation = _predicted_class_probabilities(arr).std(axis=0)
+    return _minmax(deviation) if normalize else deviation
+
+
+def predicted_vs_rest_entropy(obs: np.ndarray) -> np.ndarray:
+    """Mean predicted-versus-rest entropy across stochastic observations."""
+    arr = _validate_observations(obs)
+    per_observation = _binary_entropy(_predicted_class_probabilities(arr))
+    return per_observation.mean(axis=0)
+
+
+def predicted_vs_rest_entropy_deviation(
+    obs: np.ndarray, normalize: bool = True
+) -> np.ndarray:
+    """Deviation of predicted-versus-rest entropy across observations."""
+    arr = _validate_observations(obs)
+    per_observation = _binary_entropy(_predicted_class_probabilities(arr))
+    deviation = per_observation.std(axis=0)
+    return _minmax(deviation) if normalize else deviation
+
+
+def eprds(obs: np.ndarray, normalize_deviation: bool = True) -> np.ndarray:
+    """Entropy of Predicted vs Rest with Deviation Scaling (EPRDS).
+
+    For each sample, the stable predicted class is obtained from the mean MC
+    predictive distribution. Each observation is reduced to a binary
+    distribution: predicted class versus the sum of all remaining classes.
+    EPRDS multiplies the mean binary entropy by the across-observation entropy
+    deviation. By default, the deviation term is min-max normalized over the
+    evaluated dataset, matching the paper's use of a [0, 1] uncertainty scale.
+    """
+    arr = _validate_observations(obs)
+    per_observation = _binary_entropy(_predicted_class_probabilities(arr))
+    mean_epr = per_observation.mean(axis=0)
+    deviation = per_observation.std(axis=0)
+    if normalize_deviation:
+        deviation = _minmax(deviation)
+    return mean_epr * deviation
+
+
+# Paper-style aliases -------------------------------------------------------
+# These aliases make the code and manuscript notation directly comparable.
+M_E = mean_entropy
+E_M = entropy_mean
+Max_E = max_entropy
+DPkP = std_predicted_prob
+DPP = std_predicted_prob
+EPR = predicted_vs_rest_entropy
+EPRD = predicted_vs_rest_entropy_deviation
+EPRDS = eprds


### PR DESCRIPTION
## Status: validation required — do not merge yet

The first implementation pass does **not yet match the final thesis equations** and is being kept as a draft for correction.

Known mismatches found during thesis comparison:
- EPRDS currently multiplies mean binary entropy by normalized deviation, while the thesis uses `u = 0.5 + alpha * (h_bar - 0.5)` with `alpha` derived from normalized entropy variance.
- EDS and EDP are not yet implemented.
- DPkP is currently aliased to DPP, but the thesis defines DPkP as the average deviation of the predicted class and the top-k competitor classes.
- Selective-accuracy figures from thesis Figure 6.2 are not yet generated.

## Required validation before merge
1. Formula-level unit tests against hand-calculated examples.
2. Regression tests using saved MC-dropout probability arrays from the thesis experiments.
3. Recreate selective-accuracy, accuracy-vs-uncertainty, and uncertainty-histogram figures from those fixed arrays.
4. Compare curves and numerical summaries with thesis Tables 6.3 and 6.4.
5. Run an independent end-to-end dataset experiment with the documented 75/25 split, dropout 0.5, and T=100.

The PR should only be marked ready after these checks pass.